### PR TITLE
Set gas limit per withdrawal

### DIFF
--- a/e2e/docker-compose-e2e.yaml
+++ b/e2e/docker-compose-e2e.yaml
@@ -55,6 +55,8 @@ services:
       - mongo
       - hardhat
       - indexer
+    volumes:
+      - ..:/app
 
   hardhat:
     build:

--- a/e2e/docker-compose-e2e.yaml
+++ b/e2e/docker-compose-e2e.yaml
@@ -55,8 +55,6 @@ services:
       - mongo
       - hardhat
       - indexer
-    volumes:
-      - ..:/app
 
   hardhat:
     build:

--- a/src/web3/web3.constants.ts
+++ b/src/web3/web3.constants.ts
@@ -19,3 +19,5 @@ export const getProviderURLs = (configs: ConfigService): Array<Provider> => {
     { name: 'infura', url: configs.get('INFURA_RPC_URL') },
   ];
 };
+
+export const GAS_LIMIT_PER_WITHDRAWAL = 60000

--- a/src/web3/web3.service.ts
+++ b/src/web3/web3.service.ts
@@ -9,7 +9,7 @@ import {
   MulticallView__factory,
   MulticallView,
 } from './generated';
-import { ADDRESSES, getProviderURLs } from './web3.constants';
+import { ADDRESSES, GAS_LIMIT_PER_WITHDRAWAL, getProviderURLs } from './web3.constants';
 import { ConfigService } from 'common/config';
 import { BigNumber, ethers } from 'ethers';
 import { ContractAddress, MulticallRequest, Provider } from './web3.interface';
@@ -45,7 +45,10 @@ export class Web3Service {
 
   async callWithdrawMulticall(multicallRequests: Array<MulticallRequest>) {
     const multicall = await this.getMulticallContract();
-    return await multicall.tryAggregate(false, multicallRequests, { maxPriorityFeePerGas: this.maxPriorityFeePerGas });
+    return await multicall.tryAggregate(false, multicallRequests, {
+      maxPriorityFeePerGas: this.maxPriorityFeePerGas,
+      gasLimit: multicallRequests.length * GAS_LIMIT_PER_WITHDRAWAL,
+    });
   }
 
   async callWithdraw(bridgeAddress: string, receiverL1: string, amount: BigNumber) {


### PR DESCRIPTION
### Description

- Set the gas limit per withdrawal to 60000 units which should cover the withdrawal transaction.
- Added e2e tests to cover the gas limit.

### Checklist:

- [X]  Checked the changes locally.
- [X]  Created / updated tests (e2e / unit).