### PR TITLE
fix: attache more gas to cover new account creation

### DIFF
--- a/src/relayer/relayer.service.ts
+++ b/src/relayer/relayer.service.ts
@@ -260,7 +260,7 @@ export class RelayerService {
               withdrawal.amount,
             ),
           ]),
-          gas: bridgeMetadata.gas,
+          gas: bridgeMetadata.gas + 40000,
         });
       }
     }


### PR DESCRIPTION
### Description

- Hotfix attache more gas to cover new accounts on L1

### Checklist:

- [X]  Checked the changes locally.
- [X]  Created / updated tests (e2e / unit).