### PR TITLE
fix: expose metrics ports

### DIFF
--- a/docker-compose-dev.yaml
+++ b/docker-compose-dev.yaml
@@ -51,6 +51,7 @@ services:
       METRICS_PORT: ${METRICS_PORT}
     ports:
       - '${RELAYER_PORT}:${RELAYER_PORT}'
+      - '${METRICS_PORT}:${METRICS_PORT}'
     volumes:
       - .:/app
       - /app/node_modules

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -53,6 +53,7 @@ services:
       METRICS_PORT: ${METRICS_PORT}
     ports:
       - '${RELAYER_PORT}:${RELAYER_PORT}'
+      - '${METRICS_PORT}:${METRICS_PORT}'
     depends_on:
       - mongo
       - indexer


### PR DESCRIPTION
### Description

- Expose the metrics to another port. Now we can access the App on port 3000 and the metrics on 9090.

### Checklist:

- [X]  Checked the changes locally.
- [X]  Created / updated tests (e2e / unit).